### PR TITLE
Fix Symfony3.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "swiftmailer/swiftmailer": ">=4.2.0,~5.0",
+        "swiftmailer/swiftmailer": ">=4.2.0,~5.0,~6.0",
         "twig/twig": "~1.23|~2.0",
         "symfony/dom-crawler": "~2.3|~3.0"
     },


### PR DESCRIPTION
Fix Symfony 3.3 compatibility (swiftmailer-bundle requires swiftmailer ^6.0).